### PR TITLE
[Feature] Inclusão de novo atributo no retorno da API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## ZRP PROJECT
 
+This project was developed as part of the challenge proposed by ZRP.
 
 ### Project specifications
 
@@ -20,4 +21,16 @@
 
 #### By run app locally
 
+1. Install ruby 3.1.1, then install bundler and rails.
+2. Run ```docker-compose up db```.
+3. Adjust database.yml to access docker database.
+5. Access the folder of project and run ```bundle install```.
+5. Run ```rails db:create db:migrate```.
+6. Finally, run ```rails s```.
+
 ### How to run specs
+
+1. After cloning this project, run ```docker-compose up -d```.
+2. Access the api container with command ```docker-compose exec app bash```.
+3. Then run ```rails db:test:prepare```.
+4. Finally, just run ```rspec spec/```.

--- a/app/controllers/api/pokemons_controller.rb
+++ b/app/controllers/api/pokemons_controller.rb
@@ -7,10 +7,14 @@ module Api
 
       return render json: { message: result.message }, status: 404 if result.failure?
 
-      render json: result.abilities
+      render json: serialized_data(result)
     end
 
     private
+
+    def serialized_data(result)
+      { name: result.name, abilities: result.abilities }
+    end
 
     def pokemon_search(pokemon_name)
       SearchPokemonService.perform(pokemon_name)

--- a/app/services/search_pokemon_service.rb
+++ b/app/services/search_pokemon_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SearchPokemonService
-  attr_reader :pokemon_name
+  attr_reader :pokemon_name, :pokemon
 
   def initialize(pokemon_name)
     @pokemon_name = pokemon_name
@@ -22,17 +22,21 @@ class SearchPokemonService
   private
 
   def success(response)
-    OpenStruct.new(failure?: false, abilities: ordered_abilities(response.body))
+    @pokemon = JSON.parse(response.body)
+
+    OpenStruct.new(failure?: false, name: name, abilities: ordered_abilities)
   end
 
   def failure
     OpenStruct.new(failure?: true, message: 'Pokemon not found, try again')
   end
 
-  def ordered_abilities(body)
-    pokemons = JSON.parse(body)
+  def name
+    pokemon['name']
+  end
 
-    pokemons['abilities'].map { |a| a['ability']['name'] }.sort
+  def ordered_abilities
+    pokemon['abilities'].map { |a| a['ability']['name'] }.sort
   end
 
   def search_params

--- a/spec/services/search_pokemon_service_spec.rb
+++ b/spec/services/search_pokemon_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe SearchPokemonService do
   let(:mock_response) do
     {
+      name: 'ditto',
       abilities: [
         {
           ability: {
@@ -33,6 +34,7 @@ RSpec.describe SearchPokemonService do
       before { allow(PokeApi::FetchPokemon).to receive(:perform).and_return(OpenStruct.new(body: mock_response)) }
 
       it { expect(search_service.abilities).to contain_exactly('imposter', 'limber') }
+      it { expect(search_service.name).to eq('ditto') }
     end
   end
 end


### PR DESCRIPTION
### Motivação

Precisávamos melhorar o readme e incluir o nome do pokemon no retorno da API.

### Solução

Ajustamos o retorno do serviço para também devolver o nome do pokemon no retorno.
Depois também ajustamos o controller, criamos um método de serialização para retornar nome e habilidades do pokemon.

### Como testar

1. Usando o rspec (testes unitários), rodando ```rspec spec/```
2. Chamando a API na rota '/api/pokemons/:pokemon_name', o retorno deve ser parecido com a evidência que segue:

![image](https://user-images.githubusercontent.com/15962198/180614376-788f9702-d864-496a-8439-074bf423a77e.png)

### Links

História no Jira [XPTO](http://google.com)